### PR TITLE
pip cltk setup added, readme updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Requires [Python 3.x](https://python.org)
 # Table of Contents
 
 * [Installation](#installation)
-* [Quickstart Guide](#quickstart-guide)
+* [Language Setup](#language-setup)
 * [Web Module](#web-module)
     * [WebPage](#webpage)
 * [File Module](#file-module)
@@ -75,14 +75,14 @@ easy_install setup.py
 
 ```
 
-## Greek & Latin Users
+# Language Setup
 
-If you want to work with Greek and Latin, you need to install cltk via pip...
+The first time you use a language-specific text object, you need to run its .setup() method
 
 ```sh
+from dhelp import EnglishText
 
-# you may need admin privileges
-pip install cltk
+EnglishText('').setup()
 
 ```
 

--- a/dhelp/text/_bases_mixins.py
+++ b/dhelp/text/_bases_mixins.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import pip
 import re
 from collections import UserString
 
@@ -421,6 +422,9 @@ class CLTKMixin(NLTKMixin):
         Example:
             >>> LatinText('').setup()
         """
+        # first, download the cltk module from pip
+        pip.main(['install', 'cltk'])
+        # import cltk inline as global import errors for non-cltk users
         from cltk.corpus.utils.importer import CorpusImporter
         corpus_importer = CorpusImporter(self.options['language'])
         # loop through and attempt to download, skip any errors


### PR DESCRIPTION
Changes Proposed

* allows user to install pip cltk through the LatinText().setup() or GreekText.setup() methods
* readme updated
* validate checking on local data
* methods to optionally install more nltk (from remote) or cltk (from local) trainer & data sets
